### PR TITLE
SystemUI: fix logcat warning spam

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/BatteryMeterView.java
+++ b/packages/SystemUI/src/com/android/systemui/BatteryMeterView.java
@@ -334,14 +334,14 @@ public class BatteryMeterView extends LinearLayout implements
             mDrawable.setShowPercent(false);
             if (!showing) {
                 mBatteryPercentView = loadPercentView();
+                if (mTextColor != 0) mBatteryPercentView.setTextColor(mTextColor);
+                updatePercentText();
                 addView(mBatteryPercentView,
                         new ViewGroup.LayoutParams(
                                 LayoutParams.WRAP_CONTENT,
                                 LayoutParams.MATCH_PARENT));
                 reloadImage();
             }
-            if (mTextColor != 0) mBatteryPercentView.setTextColor(mTextColor);
-            updatePercentText();
         } else {
             if (showing) {
                 removeView(mBatteryPercentView);


### PR DESCRIPTION
* This spam occurs when displaying keyguard.

 2672  2672 W View    : requestLayout() improperly called by android.widget.TextView{8e47ff1 V.ED..... ......ID 0,0-78,105 #7f0a007c app:id/battery_percentage_view} during layout: running second layout pass
 2672  2672 W View    : requestLayout() improperly called by android.widget.TextView{8e47ff1 V.ED..... ......ID 0,0-78,105 #7f0a007c app:id/battery_percentage_view} during second layout pass: posting in next frame