### PR TITLE
[1/2] FWB: Add back transparency

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5275,6 +5275,18 @@ public final class Settings {
         public static final String RECENTS_OMNI_SWITCH_ENABLED = "recents_omni_switch";
 
         /**
+         * Transparent volume dialog
+         * @hide
+         */
+        public static final String TRANSPARENT_VOLUME_DIALOG = "transparent_volume_dialog";
+
+        /**
+         * Transparent power menu and dialogs
+         * @hide
+         */
+        public static final String TRANSPARENT_ACTIONS_DIALOG = "transparent_actions_dialog";
+
+        /**
          * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *

--- a/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
+++ b/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
@@ -298,6 +298,9 @@ public class GlobalActionsDialog implements DialogInterface.OnDismissListener,
         } else {
             WindowManager.LayoutParams attrs = mDialog.getWindow().getAttributes();
             attrs.setTitle("ActionsDialog");
+            int mActionsDialogAlpha = Settings.System.getInt(mContext.getContentResolver(),
+                    Settings.System.TRANSPARENT_ACTIONS_DIALOG, 100);
+            attrs.alpha = (float) mActionsDialogAlpha / 100;
             attrs.layoutInDisplayCutoutMode = LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
             mDialog.getWindow().setAttributes(attrs);
             mDialog.show();


### PR DESCRIPTION
* Bring back transparency for Q
  Power menu, Volume dialog

* This is a part of this commit

    commit d97e67f2512c4e2e850e6f45578c6646a3ff88eb
    Author: LorDClockaN <lordclockan@gmail.com>
    Date:   Mon Oct 3 19:17:18 2016 +0200

    Add transparency porn [1/2]

    Power menu alpha and dim
    Volume dialog alpha, stroke, dash, radius
    QS alpha, stroke, dash, radius

    Change-Id: I03eb807f1f35af305a3d57ce1c62342a94b9e432
    Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>

Change-Id: Ifd930fa183711d100f5bed2f0dd7c7ac18d6da7c
Signed-off-by: koron393 <koron393@gmail.com>