### PR TITLE
fwb: change home navigation button

### DIFF
--- a/packages/SystemUI/res/drawable/ic_sysbar_home.xml
+++ b/packages/SystemUI/res/drawable/ic_sysbar_home.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-     Copyright (C) 2018 The Android Open Source Project
-
-     Licensed under the Apache License, Version 2.0 (the "License");
-     you may not use this file except in compliance with the License.
-     You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-     Unless required by applicable law or agreed to in writing, software
-     distributed under the License is distributed on an "AS IS" BASIS,
-     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     See the License for the specific language governing permissions and
-     limitations under the License.
+    Copyright (c) 2016 AICP
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="28dp"
-    android:height="28dp"
-    android:viewportWidth="28"
-    android:viewportHeight="28">
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="88"
+        android:viewportHeight="88">
 
-    <path
-        android:fillColor="?attr/singleToneColor"
-        android:pathData="M 14 7 C 17.8659932488 7 21 10.1340067512 21 14 C 21 17.8659932488 17.8659932488 21 14 21 C 10.1340067512 21 7 17.8659932488 7 14 C 7 10.1340067512 10.1340067512 7 14 7 Z" />
+  <path
+          android:fillColor="?attr/singleToneColor"
+          android:pathData="M36.51,4.74C45.95,2.92 56.04,4.65 64.3,9.59C72.73,14.55 79.23,22.7 82.14,32.05C85.29,41.99 84.33,53.16 79.47,62.4C74.78,71.46 66.52,78.59 56.84,81.84C46.91,85.26 35.63,84.52 26.24,79.8C16.87,75.16 9.46,66.72 6.14,56.8C2.49,46.17 3.63,34.02 9.25,24.28C14.92,14.22 25.14,6.85 36.51,4.74M37.44,8.62C30.81,9.84 24.55,12.99 19.61,17.58C7.96,27.98 4.61,46.27 11.84,60.12C18.84,74.62 36.3,82.95 51.97,79.08C68.67,75.61 81.26,58.97 79.91,41.93C79.36,30.58 72.96,19.77 63.38,13.7C55.79,8.78 46.32,6.96 37.44,8.62Z"/>
+  <path
+          android:fillColor="?attr/singleToneColor"
+          android:pathData="M37.52,14.72C52.83,10.93 69.67,21.43 73.1,36.79C77.18,51.67 67.65,68.43 52.85,72.65C39.2,77.17 23.08,70.15 17.05,57.12C10.56,44.46 14.86,27.62 26.6,19.59C29.86,17.25 33.6,15.59 37.52,14.72Z"/>
 </vector>

--- a/packages/SystemUI/res/drawable/ic_sysbar_home.xml
+++ b/packages/SystemUI/res/drawable/ic_sysbar_home.xml
@@ -12,8 +12,8 @@
     limitations under the License.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
+        android:width="21dp"
+        android:height="21dp"
         android:viewportWidth="88"
         android:viewportHeight="88">
 


### PR DESCRIPTION
ホームボタンを二重円にする
![Screenshot_20200427-130753_OnePlus_Launcher](https://user-images.githubusercontent.com/54385201/80333428-fd9bd700-8888-11ea-81df-e285b2dd1a80.png)